### PR TITLE
Feat: add LoongArch build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ GOOS=linux GOARCH=mips64 go build -trimpath -ldflags '-s -w --extldflags "-stati
 GOOS=linux GOARCH=mipsle go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_linux_mipsle
 GOOS=linux GOARCH=ppc64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_linux_ppc64
 GOOS=linux GOARCH=riscv64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_linux_riscv64
+GOOS=linux GOARCH=loong64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_linux_loong64
 GOOS=linux GOARCH=s390x go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_linux_s390x
 GOOS=netbsd GOARCH=amd64 go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_netbsd_x64
 GOOS=netbsd GOARCH=arm go build -trimpath -ldflags '-s -w --extldflags "-static -fpic"' -o output/file_zip_netbsd_arm


### PR DESCRIPTION
# Brief
Add LoongArch build task to the github CI workflow.
It works fine on my machine, with Loongson 3B6000 and AOSC OS.
However, there is no 7-zip prebuild binary for LoongArch currently.
# Screenshot
<img width="1893" height="1194" alt="QQ20260314-192448" src="https://github.com/user-attachments/assets/b065153f-f2e6-4ea8-a483-879b83846888" />
